### PR TITLE
Project Card Control

### DIFF
--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -16,19 +16,38 @@
         text-align:center;
 
     }
-    .card-deck {
-        margin: auto;
-        padding-left: 10px;
-        padding-right: 10px;
+    @media (min-width: 750px) {
+        .card-columns {
+        
+        padding-left: 30px;
+        padding-right: 30px;
         padding-top: 10px;
-
-
+        column-count: 1;
+        max-width: 1020px;
+        min-width: 420px;
+        
+    }
+    }
+    .card-columns {
+        margin: auto;
+        padding-left: 150px;
+        padding-right: 150px;
+        padding-top: 10px;
+        column-count: 2;
+        max-width: 1020px;
+        min-width: 420px;
+        
     }
     .nav-profile{
         margin-top: 0%;
     }
+    .card{
+        min-width: 200px;
+        max-width: 500px;
+    }
 
-</style>
+
+    </style>
     <body>
 
     <nav th:replace="fragments.html :: main-nav"></nav>
@@ -78,7 +97,7 @@
         </tbody>
     </table>
 
-    <div class="card-deck">
+    <div class="card-columns">
         <div class="card" th:each="project : ${projectList}" >
             <img class="card-img-top m-1" src="imges/test.png" alt="Card image cap">
             <div class="card-body">
@@ -93,6 +112,7 @@
             </div>
         </div>
     </div>
+   
 
     <footer th:replace="fragments.html :: footer"></footer>
 

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -39,6 +39,12 @@
        
         
     }
+    @media(max-width: 630px){
+        .card-columns{
+            column-count: 1;
+        }
+    }
+
     .nav-profile{
         margin-top: 0%;
     }

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -45,64 +45,48 @@
     </div>
 
 
-        <!-- Project Build button -->
-        <form th:action="@{/build-project}" method="get">
-            <input type="submit" value="Build Project"/>
-        </form>
+    <!-- Project Build button -->
+    <form th:action="@{/build-project}" method="get">
+        <input type="submit" value="Build Project"/>
+    </form>
 
 
-        <table>
-            <thead>
-                <tr>
-                    <th>프로젝트 이름</th>
-                    <th>프로젝트 설명</th>
-                </tr>
+    <table>
+        <thead>
+            <tr>
+                <th>프로젝트 이름</th>
+                <th>프로젝트 설명</th>
+            </tr>
 
-            </thead>
-            <tbody>
-                <tr th:each="project : ${projectList}">
-                    <td>
-                        <!-- 프로젝트에 맞는 페이지 URL 생성 -->
-                        <!-- 깃허브처럼 바꾸고싶다. /project/projectBuilderName/projectTitle 요로코롬 -->
-                        <a th:href="@{'/project/' + ${project.id} + '/' + ${project.title}}">
-                            <span th:text="${project.title}"></span>
-                        </a>
-                        
-                    </td>
-                    <td>
-                        <span th:text="${project.subtitle}"></span>
-                    </td>
+        </thead>
+        <tbody>
+            <tr th:each="project : ${projectList}">
+                <td>
+                    <!-- 프로젝트에 맞는 페이지 URL 생성 -->
+                    <!-- 깃허브처럼 바꾸고싶다. /project/projectBuilderName/projectTitle 요로코롬 -->
+                    <a th:href="@{'/project/' + ${project.id} + '/' + ${project.title}}">
+                        <span th:text="${project.title}"></span>
+                    </a>
+                    
+                </td>
+                <td>
+                    <span th:text="${project.subtitle}"></span>
+                </td>
 
 
-                </tr>
-            </tbody>
-        </table>
+            </tr>
+        </tbody>
+    </table>
+
     <div class="card-deck">
-        <div class="card">
+        <div class="card" th:each="project : ${projectList}" >
             <img class="card-img-top m-1" src="imges/test.png" alt="Card image cap">
             <div class="card-body">
-                <h5 class="card-title">Card title</h5>
-                <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p>
-            </div>
-            <div class="card-footer">
-                <small class="text-muted">Last updated 3 mins ago</small>
-            </div>
-        </div>
-        <div class="card">
-            <img class="card-img-top " src="imges/test.png" alt="Card image cap">
-            <div class="card-body">
-                <h5 class="card-title">Card title</h5>
-                <p class="card-text">This card has supporting text below as a natural lead-in to additional content.</p>
-            </div>
-            <div class="card-footer">
-                <small class="text-muted">Last updated 3 mins ago</small>
-            </div>
-        </div>
-        <div class="card">
-            <img class="card-img-top " src="imges/test.png" alt="Card image cap">
-            <div class="card-body">
-                <h5 class="card-title">Card title</h5>
-                <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This card has even longer content than the first to show that equal height action.</p>
+                <a th:href="@{'/project/' + ${project.id} + '/' + ${project.title}}">
+                    <h5 class="card-title"  th:text="${project.title}"></h5>
+                </a>
+                
+                <p class="card-text" th:text="${project.subtitle}"></p>
             </div>
             <div class="card-footer">
                 <small class="text-muted">Last updated 3 mins ago</small>

--- a/src/main/resources/templates/main.html
+++ b/src/main/resources/templates/main.html
@@ -16,26 +16,27 @@
         text-align:center;
 
     }
-    @media (min-width: 750px) {
-        .card-columns {
+
+    .project_control{
         
-        padding-left: 30px;
-        padding-right: 30px;
-        padding-top: 10px;
-        column-count: 1;
-        max-width: 1020px;
-        min-width: 420px;
-        
+        margin: auto;
+        min-height:70px;
+        align-content: center;
+        display:flex;
+        border:1px;
+        padding: 20px;
     }
-    }
+
     .card-columns {
         margin: auto;
-        padding-left: 150px;
-        padding-right: 150px;
+        padding-left: 100px;
+        padding-right: 100px;
         padding-top: 10px;
+        padding-bottom: 30px;
         column-count: 2;
+        
         max-width: 1020px;
-        min-width: 420px;
+       
         
     }
     .nav-profile{
@@ -44,7 +45,9 @@
     .card{
         min-width: 200px;
         max-width: 500px;
+        margin: 20px;
     }
+    
 
 
     </style>
@@ -65,41 +68,22 @@
 
 
     <!-- Project Build button -->
-    <form th:action="@{/build-project}" method="get">
-        <input type="submit" value="Build Project"/>
-    </form>
+
+    <div class="project_control">
+        <form th:action="@{/build-project}" method="get">
+            <input type="submit" value="New Project"  />
+        </form>
+
+    </div>
 
 
-    <table>
-        <thead>
-            <tr>
-                <th>프로젝트 이름</th>
-                <th>프로젝트 설명</th>
-            </tr>
-
-        </thead>
-        <tbody>
-            <tr th:each="project : ${projectList}">
-                <td>
-                    <!-- 프로젝트에 맞는 페이지 URL 생성 -->
-                    <!-- 깃허브처럼 바꾸고싶다. /project/projectBuilderName/projectTitle 요로코롬 -->
-                    <a th:href="@{'/project/' + ${project.id} + '/' + ${project.title}}">
-                        <span th:text="${project.title}"></span>
-                    </a>
-                    
-                </td>
-                <td>
-                    <span th:text="${project.subtitle}"></span>
-                </td>
 
 
-            </tr>
-        </tbody>
-    </table>
 
+    <!-- project list -->
     <div class="card-columns">
         <div class="card" th:each="project : ${projectList}" >
-            <img class="card-img-top m-1" src="imges/test.png" alt="Card image cap">
+            
             <div class="card-body">
                 <a th:href="@{'/project/' + ${project.id} + '/' + ${project.title}}">
                     <h5 class="card-title"  th:text="${project.title}"></h5>
@@ -108,7 +92,7 @@
                 <p class="card-text" th:text="${project.subtitle}"></p>
             </div>
             <div class="card-footer">
-                <small class="text-muted">Last updated 3 mins ago</small>
+                <small class="text-muted" th:text="${project.buildDate}"></small>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/project/projectMain.html
+++ b/src/main/resources/templates/project/projectMain.html
@@ -4,6 +4,8 @@
 
 <head th:replace="fragments.html :: head"></head>
 <body>
+    <nav th:replace="fragments.html :: main-nav"></nav>
+
     <!-- no project member -->
     <div th:if="${!isMember}">
         your not project member


### PR DESCRIPTION
# 수정사항
프로젝트 리스트를 카드의 형태로 표현하였으며  

타임리프를 사용하여 프로젝트를 생성할 때 마다 카드가 나오게 함

화면이 클 때는 2열로 있고 좁아지면 1열로 표현됨

## 화면이 클 때
![image](https://user-images.githubusercontent.com/49122299/82963501-128d9680-9ffe-11ea-808d-34592e41771e.png)

## 화면이 작을 때
![image](https://user-images.githubusercontent.com/49122299/82963577-4072db00-9ffe-11ea-9c03-1a62fa030625.png)
